### PR TITLE
Fixes purge cycle max pk exceeding purge max pk. Closes #124

### DIFF
--- a/prism-bukkit/src/main/java/org/prism_mc/prism/bukkit/services/purge/BukkitPurgeQueue.java
+++ b/prism-bukkit/src/main/java/org/prism_mc/prism/bukkit/services/purge/BukkitPurgeQueue.java
@@ -194,8 +194,15 @@ public class BukkitPurgeQueue implements PurgeQueue {
             .asyncFirst(() -> {
                 loggingService.info("Executing next purge for query {0}...", query);
 
-                // Calculate the cycle upper bound
-                int cycleMaxPrimaryKey = cycleMinPrimaryKey + configurationService.prismConfig().purges().limit();
+                /*
+                 * Calculate the cycle upper bound.
+                 * If it exceeds the max primary key, use that instead so we're not including keys incorrectly.
+                 * Otherwise, subtract one so each cycle's max key can be each subsequent cycle's min key.
+                 */
+                int cycleMaxPrimaryKey = Math.min(
+                    cycleMinPrimaryKey + configurationService.prismConfig().purges().limit() - 1,
+                    maxPrimaryKey
+                );
                 loggingService.debug(
                     "Limiting cycle to primary keys {0} - {1}",
                     cycleMinPrimaryKey,


### PR DESCRIPTION
- Also fixes overlap of max key from one cycle and min key from the next