### PR TITLE
Reworks config commands

### DIFF
--- a/prism-bukkit/src/main/java/org/prism_mc/prism/bukkit/PrismBukkit.java
+++ b/prism-bukkit/src/main/java/org/prism_mc/prism/bukkit/PrismBukkit.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -55,7 +54,7 @@ import org.prism_mc.prism.api.storage.StorageAdapter;
 import org.prism_mc.prism.bukkit.actions.types.BukkitActionTypeRegistry;
 import org.prism_mc.prism.bukkit.commands.AboutCommand;
 import org.prism_mc.prism.bukkit.commands.CacheCommand;
-import org.prism_mc.prism.bukkit.commands.ConfigCommand;
+import org.prism_mc.prism.bukkit.commands.ConfigsCommand;
 import org.prism_mc.prism.bukkit.commands.DrainCommand;
 import org.prism_mc.prism.bukkit.commands.ExtinguishCommand;
 import org.prism_mc.prism.bukkit.commands.LookupCommand;
@@ -520,7 +519,7 @@ public class PrismBukkit implements Prism {
 
             commandManager.registerCommand(injectorProvider.injector().getInstance(AboutCommand.class));
             commandManager.registerCommand(injectorProvider.injector().getInstance(CacheCommand.class));
-            commandManager.registerCommand(injectorProvider.injector().getInstance(ConfigCommand.class));
+            commandManager.registerCommand(injectorProvider.injector().getInstance(ConfigsCommand.class));
             commandManager.registerCommand(injectorProvider.injector().getInstance(DrainCommand.class));
             commandManager.registerCommand(injectorProvider.injector().getInstance(ExtinguishCommand.class));
             commandManager.registerCommand(injectorProvider.injector().getInstance(LookupCommand.class));

--- a/prism-bukkit/src/main/java/org/prism_mc/prism/bukkit/commands/ConfigsCommand.java
+++ b/prism-bukkit/src/main/java/org/prism_mc/prism/bukkit/commands/ConfigsCommand.java
@@ -34,7 +34,7 @@ import org.prism_mc.prism.loader.services.configuration.ConfigurationService;
 import org.prism_mc.prism.loader.services.logging.LoggingService;
 
 @Command(value = "prism", alias = { "pr" })
-public class ConfigCommand {
+public class ConfigsCommand {
 
     /**
      * The alert service.
@@ -79,7 +79,7 @@ public class ConfigCommand {
      * @param storageAdapter The storage adapter
      */
     @Inject
-    public ConfigCommand(
+    public ConfigsCommand(
         BukkitAlertService alertService,
         LoggingService loggingService,
         MessageService messageService,
@@ -97,68 +97,70 @@ public class ConfigCommand {
         this.filterService = filterService;
     }
 
-    @Command("config")
+    @Command("configs")
     @Permission("prism.admin")
-    public class ConfigSubCommand {
+    public class ConfigsSubCommand {
 
-        /**
-         * Reload the config.
-         *
-         * @param sender The command sender
-         */
-        @Command("reload")
-        @Permission("prism.admin")
-        public void onReloadConfig(final CommandSender sender) {
-            configurationService.loadConfigurations();
+        @Command("prism")
+        public class ConfigSubCommand {
 
-            filterService.loadFilters();
-            alertService.loadAlerts();
+            /**
+             * Reload the config.
+             *
+             * @param sender The command sender
+             */
+            @Command("reload")
+            @Permission("prism.admin")
+            public void onReloadConfig(final CommandSender sender) {
+                configurationService.loadConfigurations();
 
-            messageService.reloadedConfig(sender);
-        }
-    }
+                filterService.loadFilters();
+                alertService.loadAlerts();
 
-    @Command("locales")
-    @Permission("prism.admin")
-    public class LocalesSubCommand {
-
-        /**
-         * Reload the locale files.
-         *
-         * @param sender The command sender
-         */
-        @Command("reload")
-        @Permission("prism.admin")
-        public void onReloadLocales(final CommandSender sender) {
-            try {
-                translationService.reloadTranslations();
-
-                messageService.reloadedLocales(sender);
-            } catch (IOException e) {
-                messageService.errorReloadLocale(sender);
-                loggingService.handleException(e);
+                messageService.reloadedConfig(sender);
             }
         }
-    }
 
-    @Command("storage-config")
-    @Permission("prism.admin")
-    public class StorageConfigSubCommand {
+        @Command("locales")
+        public class LocalesSubCommand {
 
-        /**
-         * Run the command to write a hikari properties file.
-         *
-         * @param sender The command sender
-         */
-        @Command("write-hikari")
-        public void onHikariWrite(final CommandSender sender) {
-            try {
-                storageAdapter.writeHikariPropertiesFile();
+            /**
+             * Reload the locale files.
+             *
+             * @param sender The command sender
+             */
+            @Command("reload")
+            @Permission("prism.admin")
+            public void onReloadLocales(final CommandSender sender) {
+                try {
+                    translationService.reloadTranslations();
 
-                messageService.hikariFileWritten(sender);
-            } catch (IOException e) {
-                messageService.errorWriteHikari(sender);
-                loggingService.handleException(e);
+                    messageService.reloadedLocales(sender);
+                } catch (IOException e) {
+                    messageService.errorReloadLocale(sender);
+                    loggingService.handleException(e);
+                }
+            }
+        }
+
+        @Command("storage")
+        public class StorageConfigSubCommand {
+
+            /**
+             * Run the command to write a hikari properties file.
+             *
+             * @param sender The command sender
+             */
+            @Command("write-hikari")
+            public void onHikariWrite(final CommandSender sender) {
+                try {
+                    storageAdapter.writeHikariPropertiesFile();
+
+                    messageService.hikariFileWritten(sender);
+                } catch (IOException e) {
+                    messageService.errorWriteHikari(sender);
+                    loggingService.handleException(e);
+                }
             }
         }
     }


### PR DESCRIPTION
Configs as their own commands are too confusing and `locales` steals autosuggest focus from `lookup`, so this moves them back but also properly names all three configs for consistency.