### PR TITLE
Add itemid as a searchable paramter

### DIFF
--- a/prism-api/src/main/java/org/prism_mc/prism/api/actions/ActionData.java
+++ b/prism-api/src/main/java/org/prism_mc/prism/api/actions/ActionData.java
@@ -26,6 +26,7 @@ public record ActionData(
     String material,
     short itemQuantity,
     String itemData,
+    int itemId,
     String blockNamespace,
     String blockName,
     String blockData,

--- a/prism-api/src/main/java/org/prism_mc/prism/api/actions/ItemAction.java
+++ b/prism-api/src/main/java/org/prism_mc/prism/api/actions/ItemAction.java
@@ -34,4 +34,11 @@ public interface ItemAction extends MaterialAction {
      * @return The item data string
      */
     String serializeItemData();
+
+    /**
+     * Get the item ID (database primary key for this item stack).
+     *
+     * @return The item ID, or null if not yet persisted
+     */
+    int itemId();
 }

--- a/prism-api/src/main/java/org/prism_mc/prism/api/activities/ActivityQuery.java
+++ b/prism-api/src/main/java/org/prism_mc/prism/api/activities/ActivityQuery.java
@@ -242,21 +242,21 @@ public class ActivityQuery {
             return self();
         }
 
-            /**
-             * Add a single item id.
-             *
-             * @param itemId Item id
-             * @return The builder
-             */
-            public B itemId(int itemId) {
-                if (itemIds == null) {
-                    itemIds = new ArrayList<>();
-                }
-
-                itemIds.add(itemId);
-
-                return self();
+        /**
+         * Add a single item id.
+         *
+         * @param itemId Item id
+         * @return The builder
+         */
+        public B itemId(int itemId) {
+            if (itemIds == null) {
+                itemIds = new ArrayList<>();
             }
+
+            itemIds.add(itemId);
+
+            return self();
+        }
 
         /**
          * Set the coordinate corners of a bounding box.

--- a/prism-api/src/main/java/org/prism_mc/prism/api/activities/ActivityQuery.java
+++ b/prism-api/src/main/java/org/prism_mc/prism/api/activities/ActivityQuery.java
@@ -57,6 +57,11 @@ public class ActivityQuery {
     private Collection<Integer> activityIds;
 
     /**
+     * The item ids.
+     */
+    private Collection<Integer> itemIds;
+
+    /**
      * The lower-bound timestamp.
      */
     private Long after;
@@ -236,6 +241,22 @@ public class ActivityQuery {
 
             return self();
         }
+
+            /**
+             * Add a single item id.
+             *
+             * @param itemId Item id
+             * @return The builder
+             */
+            public B itemId(int itemId) {
+                if (itemIds == null) {
+                    itemIds = new ArrayList<>();
+                }
+
+                itemIds.add(itemId);
+
+                return self();
+            }
 
         /**
          * Set the coordinate corners of a bounding box.

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/AbstractSqlStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/AbstractSqlStorageAdapter.java
@@ -821,7 +821,7 @@ public abstract class AbstractSqlStorageAdapter implements StorageAdapter {
             short itemQuantity = r.getValue(coalesce(PRISM_ACTIVITIES.AFFECTED_ITEM_QUANTITY, DSL.val(0))).shortValue();
 
             // Item ID
-            int itemId = -1;
+            int itemId;
             if (r.getValue(PRISM_ACTIVITIES.AFFECTED_ITEM_ID) != null) {
                 itemId = r.getValue(PRISM_ACTIVITIES.AFFECTED_ITEM_ID).intValue();
             }

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/AbstractSqlStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/AbstractSqlStorageAdapter.java
@@ -821,7 +821,7 @@ public abstract class AbstractSqlStorageAdapter implements StorageAdapter {
             short itemQuantity = r.getValue(coalesce(PRISM_ACTIVITIES.AFFECTED_ITEM_QUANTITY, DSL.val(0))).shortValue();
 
             // Item ID
-            int itemId;
+            int itemId = 0;
             if (r.getValue(PRISM_ACTIVITIES.AFFECTED_ITEM_ID) != null) {
                 itemId = r.getValue(PRISM_ACTIVITIES.AFFECTED_ITEM_ID).intValue();
             }

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/AbstractSqlStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/AbstractSqlStorageAdapter.java
@@ -820,6 +820,12 @@ public abstract class AbstractSqlStorageAdapter implements StorageAdapter {
             // Item quantity
             short itemQuantity = r.getValue(coalesce(PRISM_ACTIVITIES.AFFECTED_ITEM_QUANTITY, DSL.val(0))).shortValue();
 
+            // Item ID
+            int itemId = -1;
+            if (r.getValue(PRISM_ACTIVITIES.AFFECTED_ITEM_ID) != null) {
+                itemId = r.getValue(PRISM_ACTIVITIES.AFFECTED_ITEM_ID).intValue();
+            }
+
             // Affected player
             String affectedPlayerName = r.getValue(AFFECTED_PLAYERS.PLAYER);
             UUID affectedPlayerUuid = null;
@@ -873,6 +879,7 @@ public abstract class AbstractSqlStorageAdapter implements StorageAdapter {
                     material,
                     itemQuantity,
                     itemData,
+                    itemId,
                     blockNamespace,
                     blockName,
                     blockData,
@@ -914,6 +921,7 @@ public abstract class AbstractSqlStorageAdapter implements StorageAdapter {
                     material,
                     itemQuantity,
                     itemData,
+                    itemId,
                     blockNamespace,
                     blockName,
                     null,
@@ -953,6 +961,7 @@ public abstract class AbstractSqlStorageAdapter implements StorageAdapter {
                     material,
                     itemQuantity,
                     itemData,
+                    itemId,
                     blockNamespace,
                     blockName,
                     null,

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/SqlActivityQueryBuilder.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/SqlActivityQueryBuilder.java
@@ -190,6 +190,7 @@ public class SqlActivityQueryBuilder {
             PRISM_ITEMS.MATERIAL,
             coalesce(PRISM_ACTIVITIES.AFFECTED_ITEM_QUANTITY, DSL.val(0)),
             PRISM_ITEMS.DATA,
+            PRISM_ACTIVITIES.AFFECTED_ITEM_ID,
             PRISM_BLOCKS.NS,
             PRISM_BLOCKS.NAME,
             PRISM_BLOCKS.TRANSLATION_KEY,
@@ -267,6 +268,7 @@ public class SqlActivityQueryBuilder {
                 PRISM_ITEMS.MATERIAL,
                 PRISM_ACTIVITIES.AFFECTED_ITEM_QUANTITY,
                 PRISM_ITEMS.DATA,
+                PRISM_ACTIVITIES.AFFECTED_ITEM_ID,
                 PRISM_BLOCKS.NS,
                 PRISM_BLOCKS.NAME,
                 PRISM_BLOCKS.TRANSLATION_KEY,
@@ -470,6 +472,11 @@ public class SqlActivityQueryBuilder {
         // Activity IDs
         if (query.activityIds() != null && !query.activityIds().isEmpty()) {
             conditions.add(PRISM_ACTIVITIES.ACTIVITY_ID.in(query.activityIds()));
+        }
+
+        // Item IDs
+        if (query.itemIds() != null && !query.itemIds().isEmpty()) {
+            conditions.add(PRISM_ACTIVITIES.AFFECTED_ITEM_ID.in(query.itemIds()));
         }
 
         // Affected Blocks

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/PrismPaper.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/PrismPaper.java
@@ -506,6 +506,7 @@ public class PrismPaper implements Prism {
                 Argument.forString().name("at").build(),
                 Argument.forString().name("bounds").build(),
                 Argument.listOf(Integer.class).name("id").build(),
+                Argument.listOf(Integer.class).name("itemid").build(),
                 Argument.listOf(String.class).name("a").suggestion(SuggestionKey.of("actions")).build(),
                 Argument.listOf(String.class).name("btag").suggestion(SuggestionKey.of("blocktags")).build(),
                 Argument.listOf(String.class).name("etag").suggestion(SuggestionKey.of("entitytypetags")).build(),

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/actions/PaperItemStackAction.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/actions/PaperItemStackAction.java
@@ -62,6 +62,7 @@ import org.prism_mc.prism.paper.utils.TagLib;
 public class PaperItemStackAction extends PaperMaterialAction implements ItemAction {
 
     public static final @Nullable TextColor ITEM_COLOR = TextColor.fromCSSHexString("#03a5fc");
+
     /**
      * The item stack.
      */

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/actions/types/ItemActionType.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/actions/types/ItemActionType.java
@@ -52,6 +52,12 @@ public class ItemActionType extends ActionType {
             itemStack = new ItemStack(material);
         }
 
-        return new PaperItemStackAction(this, itemStack, actionData.itemQuantity(), actionData.descriptor(), actionData.itemId());
+        return new PaperItemStackAction(
+            this,
+            itemStack,
+            actionData.itemQuantity(),
+            actionData.descriptor(),
+            actionData.itemId()
+        );
     }
 }

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/actions/types/ItemActionType.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/actions/types/ItemActionType.java
@@ -52,6 +52,6 @@ public class ItemActionType extends ActionType {
             itemStack = new ItemStack(material);
         }
 
-        return new PaperItemStackAction(this, itemStack, actionData.itemQuantity(), actionData.descriptor());
+        return new PaperItemStackAction(this, itemStack, actionData.itemQuantity(), actionData.descriptor(), actionData.itemId());
     }
 }

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/query/QueryService.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/query/QueryService.java
@@ -48,6 +48,7 @@ import org.prism_mc.prism.paper.services.query.parsers.parameters.EntityTypeCaus
 import org.prism_mc.prism.paper.services.query.parsers.parameters.EntityTypeParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.EntityTypeTagParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.IdParameterParser;
+import org.prism_mc.prism.paper.services.query.parsers.parameters.ItemIdParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.InParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.ItemParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.ItemTagParameterParser;
@@ -110,6 +111,7 @@ public class QueryService {
         parsers.add(
             new InParameterParser(messageService, configurationService.prismConfig().defaults(), worldEditIntegration)
         );
+        parsers.add(new ItemIdParameterParser(messageService, configurationService.prismConfig().defaults()));
         parsers.add(new ItemParameterParser(messageService, configurationService.prismConfig().defaults()));
         parsers.add(new ItemTagParameterParser(messageService, configurationService.prismConfig().defaults()));
         parsers.add(new DescriptorParameterParser(messageService, configurationService.prismConfig().defaults()));

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/query/QueryService.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/query/QueryService.java
@@ -48,8 +48,8 @@ import org.prism_mc.prism.paper.services.query.parsers.parameters.EntityTypeCaus
 import org.prism_mc.prism.paper.services.query.parsers.parameters.EntityTypeParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.EntityTypeTagParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.IdParameterParser;
-import org.prism_mc.prism.paper.services.query.parsers.parameters.ItemIdParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.InParameterParser;
+import org.prism_mc.prism.paper.services.query.parsers.parameters.ItemIdParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.ItemParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.ItemTagParameterParser;
 import org.prism_mc.prism.paper.services.query.parsers.parameters.PlayerAffectedParameterParser;

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/query/parsers/parameters/ItemIdParameterParser.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/query/parsers/parameters/ItemIdParameterParser.java
@@ -42,10 +42,10 @@ public class ItemIdParameterParser extends IntegerSetQueryArgumentParser {
 
     @Override
     public boolean parse(
-            CommandSender sender,
-            ParameterContext parameterContext,
-            Arguments arguments,
-            PaperActivityQuery.PaperActivityQueryBuilder<?, ?> builder
+        CommandSender sender,
+        ParameterContext parameterContext,
+        Arguments arguments,
+        PaperActivityQuery.PaperActivityQueryBuilder<?, ?> builder
     ) {
         var values = parseMultipleParameters(arguments, builder);
 

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/query/parsers/parameters/ItemIdParameterParser.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/query/parsers/parameters/ItemIdParameterParser.java
@@ -1,0 +1,58 @@
+/*
+ * prism
+ *
+ * Copyright (c) 2022 M Botsko (viveleroi)
+ *                    Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.prism_mc.prism.paper.services.query.parsers.parameters;
+
+import dev.triumphteam.cmd.core.argument.keyed.Arguments;
+import org.bukkit.command.CommandSender;
+import org.prism_mc.prism.loader.services.configuration.DefaultsConfiguration;
+import org.prism_mc.prism.paper.api.activities.PaperActivityQuery;
+import org.prism_mc.prism.paper.services.messages.MessageService;
+import org.prism_mc.prism.paper.services.query.ParameterContext;
+import org.prism_mc.prism.paper.services.query.parsers.multiple.IntegerSetQueryArgumentParser;
+
+public class ItemIdParameterParser extends IntegerSetQueryArgumentParser {
+
+    /**
+     * Constructor.
+     *
+     * @param messageService The message service
+     * @param defaultsConfiguration The defaults configuration
+     */
+    public ItemIdParameterParser(MessageService messageService, DefaultsConfiguration defaultsConfiguration) {
+        super(messageService, defaultsConfiguration, "itemid");
+    }
+
+    @Override
+    public boolean parse(
+            CommandSender sender,
+            ParameterContext parameterContext,
+            Arguments arguments,
+            PaperActivityQuery.PaperActivityQueryBuilder<?, ?> builder
+    ) {
+        var values = parseMultipleParameters(arguments, builder);
+
+        if (!values.isEmpty()) {
+            builder.itemIds(values);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
This PR comprises one of the top two requests from our staff - to be able to do a lookup specific to an ItemStack, in order to track the flow of that item throughout the server.

This PR adds a new lookup parameter: "itemid" which does that. If there isn't a desire to have the itemstack be clickable to suggest the pr command that can be removed if desired, we'll leave it on in our end.

This is likely an naive/incomplete PR specific to SQL as I add my own needs to prism at this time for Loka and don't have time to try all the other storage formats.