### PR TITLE
Use displayName() for PaperItemStackAction descriptors

### DIFF
--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/actions/PaperItemStackAction.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/actions/PaperItemStackAction.java
@@ -115,31 +115,7 @@ public class PaperItemStackAction extends PaperMaterialAction implements ItemAct
                 .append(Component.space());
         }
 
-        Component itemName = Component.translatable(itemStack.translationKey());
-        if (meta != null && meta.hasItemName()) {
-            // Strip custom color/format codes out of item name for consistency
-            itemName = Component.text(
-                PlainTextComponentSerializer.plainText()
-                    .serialize(LegacyComponentSerializer.legacySection().deserialize(meta.getItemName()))
-            );
-        } else if (meta instanceof SkullMeta skullMeta && skullMeta.hasOwner()) {
-            Component name = Component.text("unknown");
-            if (skullMeta.getOwningPlayer() != null && skullMeta.getOwningPlayer().getName() != null) {
-                name = Component.text(skullMeta.getOwningPlayer().getName());
-            }
-
-            itemName = Component.translatable("block.minecraft.player_head.named", name);
-        }
-
-        complete.append(itemName);
-
-        if (meta != null && meta.hasDisplayName() && !meta.getDisplayName().isEmpty()) {
-            complete
-                .append(Component.space())
-                .append(Component.text("\""))
-                .append(Component.text(meta.getDisplayName()))
-                .append(Component.text("\""));
-        }
+        complete.append(itemStack.displayName());
 
         if (meta instanceof PotionMeta potionMeta) {
             if (


### PR DESCRIPTION
Simply use ItemStack.displayName() which nicely handles displaying a hoverable item name that respects translation, shows lores, etc
<img width="674" height="127" alt="image" src="https://github.com/user-attachments/assets/81cf1cbb-76a8-46a7-8597-8af78d808418" />
