### PR TITLE
Add `prism.inspect` permission node option to wand inspect mode

### DIFF
--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/WandCommand.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/WandCommand.java
@@ -78,8 +78,8 @@ public class WandCommand {
 
         if (
             (wandMode == WandMode.INSPECT && !canInspect) ||
-                (wandMode == WandMode.ROLLBACK && !canModify) ||
-                (wandMode == WandMode.RESTORE && !canModify)
+            (wandMode == WandMode.ROLLBACK && !canModify) ||
+            (wandMode == WandMode.RESTORE && !canModify)
         ) {
             messageService.errorInsufficientPermission(player);
 

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/WandCommand.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/WandCommand.java
@@ -73,7 +73,6 @@ public class WandCommand {
         wandMode = wandMode == null ? WandMode.INSPECT : wandMode;
 
         boolean canInspect = player.hasPermission("prism.inspect") || player.hasPermission("prism.lookup");
-
         boolean canModify = player.hasPermission("prism.modify");
 
         if (

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/WandCommand.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/WandCommand.java
@@ -72,10 +72,14 @@ public class WandCommand {
         // Set mode if none selected
         wandMode = wandMode == null ? WandMode.INSPECT : wandMode;
 
+        boolean canInspect = player.hasPermission("prism.inspect") || player.hasPermission("prism.lookup");
+
+        boolean canModify = player.hasPermission("prism.modify");
+
         if (
-            (wandMode == WandMode.INSPECT && !player.hasPermission("prism.lookup")) ||
-            (wandMode == WandMode.ROLLBACK && !player.hasPermission("prism.modify")) ||
-            (wandMode == WandMode.RESTORE && !player.hasPermission("prism.modify"))
+            (wandMode == WandMode.INSPECT && !canInspect) ||
+                (wandMode == WandMode.ROLLBACK && !canModify) ||
+                (wandMode == WandMode.RESTORE && !canModify)
         ) {
             messageService.errorInsufficientPermission(player);
 


### PR DESCRIPTION
This adds the `prism.inspect` permission node as an option to the `/prism wand inspect` permission checks. This is so that players could manually check for alterations to their builds or chests without involving moderators or administrators.

An issue regarding more granular permissions can be seen [here](https://github.com/prism/prism/issues/167), though I figured this addition was simple enough to go ahead and make a PR for it.