### PR TITLE
Fix database checks and optimizations

### DIFF
--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/HikariConfigFactories.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/HikariConfigFactories.java
@@ -87,6 +87,9 @@ public class HikariConfigFactories {
         hikariConfig.setJdbcUrl(
             "jdbc:" + (useSpy ? "p6spy:" : "") + String.format("mariadb://%s:%s/%s", host, port, database)
         );
+
+        if (storageConfiguration.mariadb().useHikariOptimizations()) applyHikariOptimizations(hikariConfig);
+
         hikariConfig.setTransactionIsolation("TRANSACTION_READ_COMMITTED");
 
         return hikariConfig;
@@ -110,18 +113,7 @@ public class HikariConfigFactories {
             "jdbc:" + (useSpy ? "p6spy:" : "") + String.format("mysql://%s:%s/%s", host, port, database)
         );
 
-        if (storageConfiguration.mysql().useHikariOptimizations()) {
-            hikariConfig.addDataSourceProperty("cachePrepStmts", true);
-            hikariConfig.addDataSourceProperty("prepStmtCacheSize", 250);
-            hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", 2048);
-            hikariConfig.addDataSourceProperty("useServerPrepStmts", true);
-            hikariConfig.addDataSourceProperty("cacheCallableStmts", true);
-            hikariConfig.addDataSourceProperty("cacheResultSetMetadata", true);
-            hikariConfig.addDataSourceProperty("cacheServerConfiguration", true);
-            hikariConfig.addDataSourceProperty("useLocalSessionState", true);
-            hikariConfig.addDataSourceProperty("elideSetAutoCommits", true);
-            hikariConfig.addDataSourceProperty("alwaysSendSetIsolation", false);
-        }
+        if (storageConfiguration.mysql().useHikariOptimizations()) applyHikariOptimizations(hikariConfig);
 
         hikariConfig.setTransactionIsolation("TRANSACTION_READ_COMMITTED");
 
@@ -214,5 +206,25 @@ public class HikariConfigFactories {
                 // ignore
             }
         }
+    }
+
+    /**
+     * Applies HikariOptimizations to hikari config.
+     *
+     * @param hikariConfig The hikari config to optimize
+     */
+    private static void applyHikariOptimizations(HikariConfig hikariConfig) {
+        hikariConfig.addDataSourceProperty("cachePrepStmts", true);
+        hikariConfig.addDataSourceProperty("prepStmtCacheSize", 250);
+        hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", 2048);
+        hikariConfig.addDataSourceProperty("useServerPrepStmts", true);
+        hikariConfig.addDataSourceProperty("cacheCallableStmts", true);
+        hikariConfig.addDataSourceProperty("cacheResultSetMetadata", true);
+        hikariConfig.addDataSourceProperty("cacheServerConfiguration", true);
+        hikariConfig.addDataSourceProperty("useLocalSessionState", true);
+        hikariConfig.addDataSourceProperty("rewriteBatchedStatements", true);
+        hikariConfig.addDataSourceProperty("elideSetAutoCommits", true);
+        hikariConfig.addDataSourceProperty("alwaysSendSetIsolation", false);
+        hikariConfig.addDataSourceProperty("maintainTimeStats", false);
     }
 }

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/mariadb/MariaDbStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/mariadb/MariaDbStorageAdapter.java
@@ -82,8 +82,14 @@ public class MariaDbStorageAdapter extends MysqlStorageAdapter {
         int majorVersion = databaseMetaData.getDatabaseMajorVersion();
         int minorVersion = databaseMetaData.getDatabaseMinorVersion();
 
-        if (majorVersion < 10 || (majorVersion == 10 && minorVersion < 2)) {
+        if (majorVersion < 10 || (majorVersion == 10 && minorVersion < 7)) {
             loggingService.warn("Your database version appears to be older than prism supports.");
+            loggingService.info("Reported database product version: {0}", databaseMetaData.getDatabaseProductVersion());
+            loggingService.info(
+                    "We think your database version is {0}.{1}",
+                    majorVersion,
+                    minorVersion
+            );
         }
     }
 }

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/mariadb/MariaDbStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/mariadb/MariaDbStorageAdapter.java
@@ -85,11 +85,7 @@ public class MariaDbStorageAdapter extends MysqlStorageAdapter {
         if (majorVersion < 10 || (majorVersion == 10 && minorVersion < 7)) {
             loggingService.warn("Your database version appears to be older than prism supports.");
             loggingService.info("Reported database product version: {0}", databaseMetaData.getDatabaseProductVersion());
-            loggingService.info(
-                    "We think your database version is {0}.{1}",
-                    majorVersion,
-                    minorVersion
-            );
+            loggingService.info("We think your database version is {0}.{1}", majorVersion, minorVersion);
         }
     }
 }

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/mysql/MysqlStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/mysql/MysqlStorageAdapter.java
@@ -190,8 +190,8 @@ public class MysqlStorageAdapter extends AbstractSqlStorageAdapter {
                     stmt.execute(drop);
                 } catch (SQLException e) {
                     loggingService.warn(
-                            "Stored procedures are enabled but could not be activated (test failed), force disabling and falling back to standard SQL. Error: {0}",
-                            e.getMessage()
+                        "Stored procedures are enabled but could not be activated (test failed), force disabling and falling back to standard SQL. Error: {0}",
+                        e.getMessage()
                     );
                     canUseRoutines = false;
                 }
@@ -293,10 +293,10 @@ public class MysqlStorageAdapter extends AbstractSqlStorageAdapter {
             loggingService.warn("Your database version appears to be older than prism supports.");
             loggingService.info("Reported database product version: {0}", databaseMetaData.getDatabaseProductVersion());
             loggingService.info(
-                    "We think your database version is {0}.{1}.{2}",
-                    majorVersion,
-                    minorVersion,
-                    patchVersion
+                "We think your database version is {0}.{1}.{2}",
+                majorVersion,
+                minorVersion,
+                patchVersion
             );
         }
     }

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/mysql/MysqlStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/mysql/MysqlStorageAdapter.java
@@ -29,7 +29,6 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.List;
 import java.util.Map;
 import org.jooq.SQLDialect;
 import org.prism_mc.prism.api.actions.types.ActionTypeRegistry;
@@ -180,24 +179,27 @@ public class MysqlStorageAdapter extends AbstractSqlStorageAdapter {
                 boolean supportsProcedures = databaseMetaData.supportsStoredProcedures();
                 loggingService.info("supports procedures: {0}", supportsProcedures);
 
-                List<String> grants = dslContext.fetch("SHOW GRANTS FOR CURRENT_USER();").into(String.class);
-                boolean canCreateRoutines = false;
+                boolean canUseRoutines = true;
+                try (Statement stmt = connection.createStatement()) {
+                    var name = String.format("%sroutine_test", prefix);
+                    var drop = String.format("DROP PROCEDURE IF EXISTS %s", name);
+                    var create = String.format("CREATE PROCEDURE %s() BEGIN END", name);
 
-                for (var grant : grants) {
-                    if (
-                        grant.contains("CREATE ROUTINE") ||
-                        grant.contains("GRANT ALL PRIVILEGES ON *.*") ||
-                        grant.contains("GRANT ALL PRIVILEGES ON " + dataSourceConfiguration.database())
-                    ) {
-                        canCreateRoutines = true;
-                        break;
-                    }
+                    stmt.execute(drop);
+                    stmt.execute(create);
+                    stmt.execute(drop);
+                } catch (SQLException e) {
+                    loggingService.warn(
+                            "Stored procedures are enabled but could not be activated (test failed), force disabling and falling back to standard SQL. Error: {0}",
+                            e.getMessage()
+                    );
+                    canUseRoutines = false;
                 }
 
-                loggingService.info("can create routines: {0}", canCreateRoutines);
+                loggingService.info("can use routines: {0}", canUseRoutines);
 
                 usingStoredProcedures =
-                    supportsProcedures && canCreateRoutines && dataSourceConfiguration.useStoredProcedures();
+                    supportsProcedures && canUseRoutines && dataSourceConfiguration.useStoredProcedures();
 
                 if (!usingStoredProcedures) {
                     dataSourceConfiguration.disallowStoredProcedures();

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/mysql/MysqlStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/mysql/MysqlStorageAdapter.java
@@ -279,8 +279,9 @@ public class MysqlStorageAdapter extends AbstractSqlStorageAdapter {
      */
     protected void versionCheck(DatabaseMetaData databaseMetaData) throws SQLException {
         int majorVersion = databaseMetaData.getDatabaseMajorVersion();
-
+        int minorVersion = databaseMetaData.getDatabaseMinorVersion();
         int patchVersion = 0;
+
         var segments = databaseMetaData.getDatabaseProductVersion().split("\\.");
         if (segments.length >= 3) {
             var patchStr = segments[2].replaceAll("-.*", "");
@@ -288,13 +289,14 @@ public class MysqlStorageAdapter extends AbstractSqlStorageAdapter {
             patchVersion = Integer.parseInt(patchStr);
         }
 
-        if (majorVersion < 8 || (majorVersion == 8 && patchVersion < 20)) {
+        if (majorVersion < 8 || (majorVersion == 8 && minorVersion == 0 && patchVersion < 20)) {
             loggingService.warn("Your database version appears to be older than prism supports.");
             loggingService.info("Reported database product version: {0}", databaseMetaData.getDatabaseProductVersion());
             loggingService.info(
-                "We think your database major version is {0} and patch version is {1}",
-                majorVersion,
-                patchVersion
+                    "We think your database version is {0}.{1}.{2}",
+                    majorVersion,
+                    minorVersion,
+                    patchVersion
             );
         }
     }

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/postgres/PostgresStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/postgres/PostgresStorageAdapter.java
@@ -130,14 +130,14 @@ public class PostgresStorageAdapter extends AbstractSqlStorageAdapter {
                 boolean supportsProcedures = databaseMetaData.supportsStoredProcedures();
                 loggingService.info("supports procedures: {0}", supportsProcedures);
 
-                var canCreateFunctions = dslContext
-                    .fetchSingle("SELECT bool_or(has_schema_privilege(oid, 'CREATE')) FROM pg_catalog.pg_namespace;")
+                var canUseFunctions = dslContext
+                    .fetchSingle("SELECT has_schema_privilege(?, 'CREATE')", configurationService.storageConfig().postgres().schema())
                     .into(Boolean.class);
-                loggingService.info("can create functions: {0}", canCreateFunctions);
+                loggingService.info("can use functions: {0}", canUseFunctions);
 
                 usingStoredProcedures =
                     supportsProcedures &&
-                    canCreateFunctions &&
+                    canUseFunctions &&
                     configurationService.storageConfig().postgres().useStoredProcedures();
 
                 if (!usingStoredProcedures) {

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/postgres/PostgresStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/postgres/PostgresStorageAdapter.java
@@ -131,7 +131,10 @@ public class PostgresStorageAdapter extends AbstractSqlStorageAdapter {
                 loggingService.info("supports procedures: {0}", supportsProcedures);
 
                 var canUseFunctions = dslContext
-                    .fetchSingle("SELECT has_schema_privilege(?, 'CREATE')", configurationService.storageConfig().postgres().schema())
+                    .fetchSingle(
+                        "SELECT has_schema_privilege(?, 'CREATE')",
+                        configurationService.storageConfig().postgres().schema()
+                    )
                     .into(Boolean.class);
                 loggingService.info("can use functions: {0}", canUseFunctions);
 

--- a/prism-loader/src/main/java/org/prism_mc/prism/loader/services/configuration/storage/MysqlDataSourceConfiguration.java
+++ b/prism-loader/src/main/java/org/prism_mc/prism/loader/services/configuration/storage/MysqlDataSourceConfiguration.java
@@ -39,7 +39,7 @@ public class MysqlDataSourceConfiguration extends SqlDataSourceConfiguration {
         """
         Enable stored procedures. Stored procedures allow Prism to modify database records
         more efficiently and with reduced network traffic.
-        However, your account must have privileges to `CREATE ROUTINE`.
+        However, your account must have privileges to `CREATE ROUTINE` and `ALTER ROUTINE`.
         If you use a shared database, you likely do NOT have such permission.
         If you're unsure, Prism tells you in the server console during server startup.
         Prism will force disable this setting if you do not have necessary permission."""


### PR DESCRIPTION
- Fixed MySQL version check logic and aligned MariaDB with docs requirement
- Applied Hikari optimizations to MySQL/MariaDB, and added two missing properties
- Replaced string-based check with execution test to check MySQL/MariaDB stored procedure capabilities
- Switched to checking PostgreSQL `CREATE` privileges on the configured schema rather than performing global scan