### PR TITLE
Fixes potential connection leak

### DIFF
--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/SqlActivityProcedureBatch.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/SqlActivityProcedureBatch.java
@@ -270,10 +270,12 @@ public class SqlActivityProcedureBatch implements ActivityBatch {
     public void commitBatch() throws SQLException {
         try {
             statement.executeBatch();
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
         } finally {
-            statement.close();
+            try {
+                statement.close();
+            } catch (SQLException e) {
+                loggingService.handleException(e);
+            }
             connection.close();
         }
     }


### PR DESCRIPTION
In commitBatch(), statement.close() and connection.close() were called sequentially in a finally block with no protection between them. If statement.close() threw an SQLException, the exception would propagate out of the finally block and connection.close() would never execute, leaking that connection from the HikariCP pool.

Additionally, the catch block wrapped SQLException in a RuntimeException despite the method already declaring throws SQLException, which both changed the exception type unnecessarily and risked losing the original exception if the finally block also threw.

The fix wraps statement.close() in its own try/catch so that a failure closing the statement is logged but does not prevent connection.close() from always running. The redundant catch block is removed so executeBatch() failures propagate naturally as checked exceptions.