### PR TITLE
Tweak purge messaging/logging, removes unnecessary flags. Fixes #260

### DIFF
--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/PrismPaper.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/PrismPaper.java
@@ -529,6 +529,12 @@ public class PrismPaper implements Prism {
                 Argument.forString().name("descriptor").build()
             );
 
+            commandManager.registerFlags(
+                FlagKey.of("purge-flags"),
+                Flag.flag("nd").longFlag("nodefaults").build(),
+                Flag.flag("v").longFlag("verbose").build()
+            );
+
             commandManager.registerCommand(injectorProvider.injector().getInstance(AboutCommand.class));
             commandManager.registerCommand(injectorProvider.injector().getInstance(CacheCommand.class));
             commandManager.registerCommand(injectorProvider.injector().getInstance(ConfigsCommand.class));

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/PurgeCommand.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/PurgeCommand.java
@@ -88,7 +88,7 @@ public class PurgeCommand {
          * @param sender The command sender
          * @param arguments The arguments
          */
-        @CommandFlags(key = "query-flags")
+        @CommandFlags(key = "purge-flags")
         @NamedArguments("query-parameters")
         @Command("start")
         public void onPurgeStart(final CommandSender sender, final Arguments arguments) {
@@ -107,9 +107,12 @@ public class PurgeCommand {
                     messageService.defaultsUsed(sender, String.join(" ", query.defaultsUsed()));
                 }
 
+                boolean verbose = arguments.hasFlag("verbose");
                 PurgeQueue purgeQueue = purgeService.newQueue(
                     result -> {
-                        messageService.purgeCycle(sender, result);
+                        if (verbose) {
+                            messageService.purgeCycle(sender, result);
+                        }
                     },
                     result -> messageService.purgeComplete(sender, result.deleted())
                 );

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/purge/PaperPurgeQueue.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/purge/PaperPurgeQueue.java
@@ -162,7 +162,7 @@ public class PaperPurgeQueue implements PurgeQueue {
         if (purgeQueue.isEmpty()) {
             running = false;
 
-            loggingService.info("Purge queue now empty, finishing.");
+            loggingService.debug("Purge queue now empty, finishing.");
 
             onEnd.accept(PurgeResult.builder().deleted(deleted).build());
 
@@ -192,7 +192,7 @@ public class PaperPurgeQueue implements PurgeQueue {
         taskChainProvider
             .newChain()
             .asyncFirst(() -> {
-                loggingService.info("Executing next purge for query {0}...", query);
+                loggingService.debug("Executing next purge for query {0}...", query);
 
                 /*
                  * Calculate the cycle upper bound.
@@ -203,6 +203,7 @@ public class PaperPurgeQueue implements PurgeQueue {
                     cycleMinPrimaryKey + configurationService.prismConfig().purges().limit() - 1,
                     maxPrimaryKey
                 );
+
                 loggingService.debug(
                     "Limiting cycle to primary keys {0} - {1}",
                     cycleMinPrimaryKey,
@@ -221,7 +222,7 @@ public class PaperPurgeQueue implements PurgeQueue {
                         .maxPrimaryKey(cycleMaxPrimaryKey)
                         .build()
                 );
-                loggingService.info("Purged {0} activity records", count);
+                loggingService.debug("Purged {0} activity records", count);
 
                 // Advance our starting pk for the next cycle
                 int nextCycleMinPrimaryKey = cycleMinPrimaryKey + configurationService.prismConfig().purges().limit();
@@ -232,7 +233,7 @@ public class PaperPurgeQueue implements PurgeQueue {
                     purgeQueue.remove(0);
                 }
 
-                loggingService.info("Scheduling next cycle (and any configured delay)");
+                loggingService.debug("Scheduling next cycle (and any configured delay)");
 
                 return nextCycleMinPrimaryKey;
             })


### PR DESCRIPTION
- Adds a `--verbose` flag to purges for per-cycle in-game messages
- In-game per-cycle messages hidden by default
- Changes most purge log message to debug levels
- Removes rollback-only query flags from purge command (drainlava, etc)