### PR TITLE
Use stored BlockState instead of re-fetching from world on preview cancel

### DIFF
--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/modifications/PaperModificationQueueService.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/modifications/PaperModificationQueueService.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.bukkit.Location;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.prism_mc.prism.api.activities.Activity;
@@ -196,8 +195,7 @@ public class PaperModificationQueueService implements ModificationQueueService {
 
                 if (result.stateChange() instanceof BlockStateChange blockStateChange) {
                     Location loc = blockStateChange.oldState().getLocation();
-                    BlockData liveBlockData = loc.getWorld().getBlockData(loc);
-                    player.sendBlockChange(loc, liveBlockData);
+                    player.sendBlockChange(loc, blockStateChange.oldState().getBlockData());
                 }
 
                 iterator.remove();


### PR DESCRIPTION
When cancelling a preview, cancelPreview() called loc.getWorld().getBlockData(loc) for every previewed block to send the "real" state back to the player. Since preview mode never modifies the world, the oldState stored in BlockStateChange already IS the live state. Using it directly avoids a per-block world lookup and chunk access for every cancelled preview block.