### PR TITLE
Fixes kyori api change in paper 26.2. Fixes #360

### DIFF
--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/actions/PaperItemStackAction.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/actions/PaperItemStackAction.java
@@ -126,7 +126,7 @@ public class PaperItemStackAction extends PaperMaterialAction implements ItemAct
             complete.append(Component.text(")"));
         }
 
-        return complete.hoverEvent(itemStack).build();
+        return complete.hoverEvent(itemStack).asComponent();
     }
 
     @Override

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/AboutCommand.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/AboutCommand.java
@@ -71,7 +71,7 @@ public class AboutCommand {
             .append(link("Discord", "https://discord.gg/7FxZScH4EJ"))
             .append(Component.text(" "))
             .append(link("Docs", "https://docs.prism-mc.org"))
-            .build();
+            .asComponent();
 
         sender.sendMessage(links);
     }
@@ -101,6 +101,6 @@ public class AboutCommand {
             .append(Component.text("]", NamedTextColor.AQUA))
             .clickEvent(ClickEvent.openUrl(url))
             .hoverEvent(HoverEvent.showText(Component.text("Click to open in a browser")))
-            .build();
+            .asComponent();
     }
 }

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/messages/resolvers/ActivityPlaceholderResolver.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/messages/resolvers/ActivityPlaceholderResolver.java
@@ -163,7 +163,7 @@ public class ActivityPlaceholderResolver implements IPlaceholderResolver<Command
             .append(Component.text(" or ", NamedTextColor.WHITE))
             .append(Component.text("a:", NamedTextColor.GRAY))
             .append(Component.text(actionType.familyKey(), TextColor.fromCSSHexString("#ffd782")))
-            .build();
+            .asComponent();
 
         var builder = Component.text()
             .append(Component.translatable(actionType.pastTenseTranslationKey()))
@@ -173,7 +173,7 @@ public class ActivityPlaceholderResolver implements IPlaceholderResolver<Command
             builder.decorate(TextDecoration.STRIKETHROUGH);
         }
 
-        return builder.build();
+        return builder.asComponent();
     }
 
     /**
@@ -221,12 +221,12 @@ public class ActivityPlaceholderResolver implements IPlaceholderResolver<Command
                 .append(banned)
                 .append(Component.text(" "))
                 .append(Component.text(offlinePlayer.isBanned() ? yes : no, NamedTextColor.WHITE))
-                .build();
+                .asComponent();
 
             return Component.text()
                 .append(Component.text(playerContainer.name()))
                 .hoverEvent(HoverEvent.showText(hover))
-                .build();
+                .asComponent();
         } else if (cause.container() instanceof TranslatableContainer translatableContainer) {
             return Component.translatable(translatableContainer.translationKey());
         } else {
@@ -285,14 +285,14 @@ public class ActivityPlaceholderResolver implements IPlaceholderResolver<Command
                 i++;
             }
 
-            builder.hoverEvent(HoverEvent.showText(metadataBuilder.build()));
+            builder.hoverEvent(HoverEvent.showText(metadataBuilder.asComponent()));
         }
 
         if (value.reversed()) {
             builder.decorate(TextDecoration.STRIKETHROUGH);
         }
 
-        return builder.build();
+        return builder.asComponent();
     }
 
     /**
@@ -326,7 +326,7 @@ public class ActivityPlaceholderResolver implements IPlaceholderResolver<Command
             builder.clickEvent(ClickEvent.runCommand(command));
         }
 
-        return builder.build();
+        return builder.asComponent();
     }
 
     /**

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/messages/resolvers/BlockBreakAlertDataPlaceholderResolver.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/messages/resolvers/BlockBreakAlertDataPlaceholderResolver.java
@@ -49,7 +49,7 @@ public class BlockBreakAlertDataPlaceholderResolver
         final Method method,
         final @Nullable Object[] parameters
     ) {
-        Component color = Component.text().color(value.color()).build();
+        Component color = Component.text().color(value.color()).asComponent();
         Component blockName = block(value.blockTranslationKey(), value.itemKey());
         Component playerName = Component.text(value.playerName());
         Component count = Component.text(value.count());
@@ -80,6 +80,6 @@ public class BlockBreakAlertDataPlaceholderResolver
         return Component.text()
             .append(Component.translatable(blockTranslationKey))
             .hoverEvent(HoverEvent.hoverEvent(HoverEvent.Action.SHOW_ITEM, HoverEvent.ShowItem.showItem(itemKey, 1)))
-            .build();
+            .asComponent();
     }
 }

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/messages/resolvers/ItemAlertDataPlaceholderResolver.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/messages/resolvers/ItemAlertDataPlaceholderResolver.java
@@ -48,7 +48,7 @@ public class ItemAlertDataPlaceholderResolver implements IPlaceholderResolver<Co
         final Method method,
         final @Nullable Object[] parameters
     ) {
-        Component color = Component.text().color(value.color()).build();
+        Component color = Component.text().color(value.color()).asComponent();
         Component objectName = item(value.translationKey(), value.itemKey());
         Component playerName = Component.text(value.playerName());
 
@@ -73,6 +73,6 @@ public class ItemAlertDataPlaceholderResolver implements IPlaceholderResolver<Co
         return Component.text()
             .append(Component.translatable(translationKey))
             .hoverEvent(HoverEvent.hoverEvent(HoverEvent.Action.SHOW_ITEM, HoverEvent.ShowItem.showItem(itemKey, 1)))
-            .build();
+            .asComponent();
     }
 }

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/messages/resolvers/ModificationQueueResultPlaceholderResolver.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/messages/resolvers/ModificationQueueResultPlaceholderResolver.java
@@ -96,7 +96,7 @@ public class ModificationQueueResultPlaceholderResolver
                 .clickEvent(ClickEvent.runCommand("/prism report partial"));
         }
 
-        return builder.build();
+        return builder.asComponent();
     }
 
     /**
@@ -119,6 +119,6 @@ public class ModificationQueueResultPlaceholderResolver
                 .clickEvent(ClickEvent.runCommand("/prism report skips"));
         }
 
-        return builder.build();
+        return builder.asComponent();
     }
 }

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/pagination/PaginationService.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/pagination/PaginationService.java
@@ -176,7 +176,7 @@ public class PaginationService {
                 );
             }
 
-            sender.sendMessage(builder.build());
+            sender.sendMessage(builder.asComponent());
         }
     }
 }


### PR DESCRIPTION
Uses asComponent rather than build. Adventure 5 (Paper 26.2+) removed BuildableComponent, changing ComponentBuilder#build()'s erased return type from BuildableComponent to Component.