### PR TITLE
Allow new flags for wands

### DIFF
--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/WandCommand.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/commands/WandCommand.java
@@ -94,8 +94,7 @@ public class WandCommand {
         @NamedArguments("query-parameters")
         @Command(Command.DEFAULT_CMD_NAME)
         public void onWand(final Player player, final Arguments arguments) {
-            boolean hasConfiguration =
-                queryService.hasAnyParameter(arguments) || queryService.hasAnyQueryFlag(arguments);
+            boolean hasConfiguration = queryService.hasAnyParameter(arguments) || queryService.hasAnyFlag(arguments);
 
             if (!hasConfiguration && wandService.hasActiveWand(player)) {
                 wandService.deactivateWand(player);
@@ -146,8 +145,7 @@ public class WandCommand {
         }
 
         private void onModeCommand(Player player, WandMode wandMode, Arguments arguments) {
-            boolean hasConfiguration =
-                queryService.hasAnyParameter(arguments) || queryService.hasAnyQueryFlag(arguments);
+            boolean hasConfiguration = queryService.hasAnyParameter(arguments) || queryService.hasAnyFlag(arguments);
 
             java.util.Optional<Wand> activeWand = wandService.getWand(player);
             if (activeWand.isPresent() && activeWand.get().mode().equals(wandMode) && !hasConfiguration) {

--- a/prism-paper/src/main/java/org/prism_mc/prism/paper/services/query/QueryService.java
+++ b/prism-paper/src/main/java/org/prism_mc/prism/paper/services/query/QueryService.java
@@ -124,11 +124,6 @@ public class QueryService {
     );
 
     /**
-     * Query flag names.
-     */
-    public static final Set<String> QUERY_FLAGS = Set.of("count", "nogroup", "sort");
-
-    /**
      * The ID parameter parser, which has the highest priority.
      */
     private final IdParameterParser idParameterParser;
@@ -266,13 +261,13 @@ public class QueryService {
     }
 
     /**
-     * Check if any query flags are present.
+     * Check if any command flag is present.
      *
      * @param arguments The arguments
-     * @return True if a grouping/count/sort flag is present
+     * @return True if the sender supplied any flag (query or modification)
      */
-    public boolean hasAnyQueryFlag(Arguments arguments) {
-        return arguments.getAllFlags().stream().anyMatch(QUERY_FLAGS::contains);
+    public boolean hasAnyFlag(Arguments arguments) {
+        return !arguments.getAllFlags().isEmpty();
     }
 
     /**


### PR DESCRIPTION
The wand reconfigure check only recognized count/nogroup/sort, so reconfiguring an active wand with a modification flag (-ow/-dl/-ph/-rd) or -nd was treated as "no configuration" and toggled the wand off instead of reconfiguring it. Broaden the check to any supplied flag.