### PR TITLE
Does not parameterize internal keys

### DIFF
--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/AbstractSqlStorageAdapter.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/AbstractSqlStorageAdapter.java
@@ -1345,7 +1345,7 @@ public abstract class AbstractSqlStorageAdapter implements StorageAdapter {
             dslContext
                 .update(PRISM_ACTIVITIES)
                 .set(PRISM_ACTIVITIES.REVERSED, reversed)
-                .where(PRISM_ACTIVITIES.ACTIVITY_ID.in(chunk))
+                .where(PRISM_ACTIVITIES.ACTIVITY_ID.in(chunk.stream().map(DSL::inline).toList()))
                 .execute();
         }
     }

--- a/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/SqlActivityQueryBuilder.java
+++ b/prism-core/src/main/java/org/prism_mc/prism/core/storage/adapters/sql/SqlActivityQueryBuilder.java
@@ -348,7 +348,7 @@ public class SqlActivityQueryBuilder {
             pkValues.add(UInteger.valueOf(pk));
         }
 
-        queryBuilder.addConditions(PRISM_ACTIVITIES.ACTIVITY_ID.in(pkValues));
+        queryBuilder.addConditions(PRISM_ACTIVITIES.ACTIVITY_ID.in(pkValues.stream().map(DSL::inline).toList()));
 
         if (query.modification()) {
             addModificationOrdering(queryBuilder);
@@ -717,9 +717,8 @@ public class SqlActivityQueryBuilder {
         Collection<String> excluded
     ) {
         if (!included.isEmpty()) {
-            conditions.add(
-                outerField.in(dslContext.select(idField).from(table).where(nameField.in(included)).fetch(idField))
-            );
+            var includedIds = dslContext.select(idField).from(table).where(nameField.in(included)).fetch(idField);
+            conditions.add(outerField.in(includedIds.stream().map(DSL::inline).toList()));
         }
 
         if (!excluded.isEmpty()) {
@@ -727,15 +726,8 @@ public class SqlActivityQueryBuilder {
             // silently drop every row whose FK is null (e.g. excluding a cause
             // player would also exclude all non-player-caused activities). Keep
             // null-FK rows by OR-ing an explicit IS NULL check.
-            conditions.add(
-                outerField
-                    .isNull()
-                    .or(
-                        outerField.notIn(
-                            dslContext.select(idField).from(table).where(nameField.in(excluded)).fetch(idField)
-                        )
-                    )
-            );
+            var excludedIds = dslContext.select(idField).from(table).where(nameField.in(excluded)).fetch(idField);
+            conditions.add(outerField.isNull().or(outerField.notIn(excludedIds.stream().map(DSL::inline).toList())));
         }
     }
 


### PR DESCRIPTION
Fixes a performance issue in mysql/mariadb where binding these keys as parameters slows the query down immensely, yet running it with keys as literals runs much faster.